### PR TITLE
Add mhsendmail for optional mailhandling by MailHog

### DIFF
--- a/Dockerfiles/work/Dockerfile-5.3
+++ b/Dockerfiles/work/Dockerfile-5.3
@@ -146,6 +146,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-5.4
+++ b/Dockerfiles/work/Dockerfile-5.4
@@ -156,6 +156,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-5.5
+++ b/Dockerfiles/work/Dockerfile-5.5
@@ -159,6 +159,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-5.6
+++ b/Dockerfiles/work/Dockerfile-5.6
@@ -159,6 +159,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-7.0
+++ b/Dockerfiles/work/Dockerfile-7.0
@@ -159,6 +159,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-7.1
+++ b/Dockerfiles/work/Dockerfile-7.1
@@ -159,6 +159,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-7.2
+++ b/Dockerfiles/work/Dockerfile-7.2
@@ -159,6 +159,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/Dockerfiles/work/Dockerfile-7.3
+++ b/Dockerfiles/work/Dockerfile-7.3
@@ -159,6 +159,11 @@ RUN set -x \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
 && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
  \
+# mhsendmail
+	&& wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+&& chmod +x mhsendmail_linux_amd64 \
+&& mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
+ \
 # mysqldumpsecure
 	&& git clone https://github.com/cytopia/mysqldump-secure.git /usr/local/src/mysqldump-secure \
 && cd /usr/local/src/mysqldump-secure \

--- a/build/ansible/group_vars/all.yml
+++ b/build/ansible/group_vars/all.yml
@@ -61,6 +61,7 @@ software_enabled:
   - grunt
   - laravel
   - linuxbrew
+  - mhsendmail
   - mysqldumpsecure
   - phalcon
   - phpcs
@@ -266,6 +267,12 @@ software_available:
         	'echo "export INFOPATH=/usr/local/src/linuxbrew/share/man:${INFOPATH}" >> /home/devilbox/${v}' \
         && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew update' \
         && su - ${MY_USER} -c '/usr/local/src/linuxbrew/bin/brew config' \
+  mhsendmail:
+    all:
+      command: |
+        wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+        && chmod +x mhsendmail_linux_amd64 \
+        && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmai \
   mysqldumpsecure:
     check: mysqldump-secure --version | grep -E 'Version:\s*[.0-9]+'
     all:


### PR DESCRIPTION
mhsendmail can be used in php.ini instead of sendmail. If you have a service named 'mailhog' the configuration would be:
`sendmail_path = '/usr/local/bin/mhsendmail --smtp-addr="mailhog:1025"'`