### PR TITLE
Fix default listen.backlog value

### DIFF
--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.2.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.2.conf
@@ -40,7 +40,7 @@
 
 			<value name="listen_options">
 				Set listen(2) backlog
-				<value name="backlog">128</value>
+				<value name="backlog">1024</value>
 				Set permissions for unix socket, if one used.
 				In Linux read/write permissions must be set in order to allow connections from web server.
 				Many BSD-derrived systems allow connections regardless of permissions.

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.3.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.3.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.4.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.4.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.5.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.5.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.6.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-5.6.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.0.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.0.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.1.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.1.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.2.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.2.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.3.conf
+++ b/Dockerfiles/base/data/php-fpm.conf/php-fpm-7.3.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.2.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.2.conf
@@ -40,7 +40,7 @@
 
 			<value name="listen_options">
 				Set listen(2) backlog
-				<value name="backlog">128</value>
+				<value name="backlog">1024</value>
 				Set permissions for unix socket, if one used.
 				In Linux read/write permissions must be set in order to allow connections from web server.
 				Many BSD-derrived systems allow connections regardless of permissions.

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.3.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.3.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.4.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.4.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.5.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.5.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.6.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-5.6.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.0.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.0.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.1.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.1.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.2.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.2.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.3.conf
+++ b/Dockerfiles/work/data/php-fpm.conf/php-fpm-7.3.conf
@@ -41,7 +41,7 @@ access.log = /proc/self/fd/2
 
 ; This should not be greater than `cat /proc/sys/net/core/somaxconn`, otherwise connections
 ; are silently truncated
-listen.backlog = 128
+listen.backlog = 1024
 
 
 ; ############################################################

--- a/build/ansible/group_vars/all.yml
+++ b/build/ansible/group_vars/all.yml
@@ -96,7 +96,7 @@ php_settings_fpm:
     # Network
     listen:                    9000
     # Backlog
-    listen_backlog:            128
+    listen_backlog:            1024
     # Logging
     log_level:                 notice
     error_log:                 /proc/self/fd/2


### PR DESCRIPTION
Changing `listen.backlog` from 128 to 1024

Refs: https://github.com/cytopia/devilbox/issues/234