### PR TITLE
Add xdebug to PHP-FPM 7.3

### DIFF
--- a/Dockerfiles/mods/Dockerfile-7.3
+++ b/Dockerfiles/mods/Dockerfile-7.3
@@ -349,6 +349,12 @@ RUN set -x \
 	&& (rm -rf /usr/local/lib/php/test/wddx || true) \
 	&& (rm -rf /usr/local/lib/php/doc/wddx || true) \
 	\
+# ---- Installing PHP Extension: xdebug ----
+	&& pecl install xdebug-2.7.0beta1 \
+	&& docker-php-ext-enable xdebug \
+	&& (rm -rf /usr/local/lib/php/test/xdebug || true) \
+	&& (rm -rf /usr/local/lib/php/doc/xdebug || true) \
+	\
 # ---- Installing PHP Extension: xmlrpc ----
 	&& /usr/local/bin/docker-php-ext-configure xmlrpc --with-libxml-dir=/usr --with-iconv-dir=/usr \
 	&& /usr/local/bin/docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) xmlrpc \
@@ -531,6 +537,8 @@ RUN set -x \
 	&& php-fpm -m | grep -oiE '^uploadprogress$' \
 	&& php -m | grep -oiE '^wddx$' \
 	&& php-fpm -m | grep -oiE '^wddx$' \
+	&& php -m | grep -oiE '^xdebug$' \
+	&& php-fpm -m | grep -oiE '^xdebug$' \
 	&& php -m | grep -oiE '^xml$' \
 	&& php-fpm -m | grep -oiE '^xml$' \
 	&& php -m | grep -oiE '^xmlreader$' \

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Check out this table to see which Docker image provides what PHP modules.
   <tr>
    <th>7.3</th>
    <td id="73-base">Core, ctype, curl, date, dom, fileinfo, filter, ftp, hash, iconv, json, libxml, mbstring, mysqlnd, openssl, pcre, PDO, pdo_sqlite, Phar, posix, readline, Reflection, session, SimpleXML, sodium, SPL, sqlite3, standard, tokenizer, xml, xmlreader, xmlwriter, zlib</td>
-   <td id="73-mods">apcu, bcmath, bz2, calendar, Core, ctype, curl, date, dba, dom, enchant, exif, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, igbinary, imagick, imap, interbase, intl, json, ldap, libxml, mbstring, mcrypt, memcached, mongodb, mysqli, mysqlnd, openssl, pcntl, pcre, PDO, pdo_dblib, PDO_Firebird, pdo_mysql, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, pspell, rdkafka, readline, recode, redis, Reflection, session, shmop, SimpleXML, snmp, soap, sockets, sodium, SPL, sqlite3, standard, swoole, sysvmsg, sysvsem, sysvshm, tidy, tokenizer, uploadprogress, wddx, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib</td>
+   <td id="73-mods">apcu, bcmath, bz2, calendar, Core, ctype, curl, date, dba, dom, enchant, exif, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, igbinary, imagick, imap, interbase, intl, json, ldap, libxml, mbstring, mcrypt, memcached, mongodb, mysqli, mysqlnd, openssl, pcntl, pcre, PDO, pdo_dblib, PDO_Firebird, pdo_mysql, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, pspell, rdkafka, readline, recode, redis, Reflection, session, shmop, SimpleXML, snmp, soap, sockets, sodium, SPL, sqlite3, standard, swoole, sysvmsg, sysvsem, sysvshm, tidy, tokenizer, uploadprogress, wddx, xdebug, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib</td>
   </tr>
   <tr>
    <th>7.4</th>

--- a/build/ansible/group_vars/all.yml
+++ b/build/ansible/group_vars/all.yml
@@ -1433,7 +1433,7 @@ extensions_available:
       configure: --with-libxml-dir=/usr
       build_dep: [libxml2-dev]
   xdebug:
-    disabled: [7.3, 7.4]
+    disabled: [7.4]
     5.2:
       type: pecl
       version: 2.2.7
@@ -1449,6 +1449,9 @@ extensions_available:
     5.6:
       type: pecl
       version: 2.4.1
+    7.3:
+      type: pecl
+      version: 2.7.0beta1
     all:
       type: pecl
   xml:


### PR DESCRIPTION
# Add xdebug to PHP-FPM 7.3

This PR adds xdebug (xdebug-2.7.0beta1) support for PHP 7.3