### PR TITLE
Add FFI (Foreign Function Interface) to PHP 7.4

### DIFF
--- a/Dockerfiles/mods/Dockerfile-7.4
+++ b/Dockerfiles/mods/Dockerfile-7.4
@@ -29,6 +29,7 @@ ENV BUILD_DEPS \
 	libenchant-dev \
 	libevent-dev \
 	libfbclient2 \
+	libffi-dev \
 	libfreetype6-dev \
 	libgmp-dev \
 	libhiredis-dev \
@@ -65,6 +66,7 @@ ENV RUN_DEPS \
 	libc-client2007e \
 	libenchant1c2a \
 	libfbclient2 \
+	libffi6 \
 	libfreetype6 \
 	libhiredis0.13 \
 	libicu57 \
@@ -125,6 +127,20 @@ RUN set -x \
 	&& /usr/local/bin/docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) exif \
 	&& (rm -rf /usr/local/lib/php/test/exif || true) \
 	&& (rm -rf /usr/local/lib/php/doc/exif || true) \
+	\
+# ---- Installing PHP Extension: ffi ----
+	&& git clone https://github.com/dstogov/php-ffi /tmp/ffi \
+	&& cd /tmp/ffi \
+	&& curl -sS -O https://github.com/fpoirotte/php-ffi/commit/734630fe3d2e3efd343d3f3636b58446abd9c941.diff \
+&& git apply 734630fe3d2e3efd343d3f3636b58446abd9c941.diff \
+&& phpize \
+&& ./configure --with-ffi \
+&& make -j$(getconf _NPROCESSORS_ONLN) \
+&& make install \
+ \
+	&& docker-php-ext-enable ffi \
+	&& (rm -rf /usr/local/lib/php/test/ffi || true) \
+	&& (rm -rf /usr/local/lib/php/doc/ffi || true) \
 	\
 # ---- Installing PHP Extension: gd ----
 	&& ln -s /usr/lib/x86_64-linux-gnu/libXpm.* /usr/lib/ \
@@ -444,6 +460,8 @@ RUN set -x \
 	&& php-fpm -m | grep -oiE '^enchant$' \
 	&& php -m | grep -oiE '^exif$' \
 	&& php-fpm -m | grep -oiE '^exif$' \
+	&& php -m | grep -oiE '^ffi$' \
+	&& php-fpm -m | grep -oiE '^ffi$' \
 	&& php -m | grep -oiE '^fileinfo$' \
 	&& php-fpm -m | grep -oiE '^fileinfo$' \
 	&& php -m | grep -oiE '^filter$' \

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Check out this table to see which Docker image provides what PHP modules.
   <tr>
    <th>7.4</th>
    <td id="74-base">Core, ctype, curl, date, dom, fileinfo, filter, ftp, hash, iconv, json, libxml, mbstring, mysqlnd, openssl, pcre, PDO, pdo_sqlite, Phar, posix, readline, Reflection, session, SimpleXML, sodium, SPL, sqlite3, standard, tokenizer, xml, xmlreader, xmlwriter, zlib</td>
-   <td id="74-mods">bcmath, bz2, calendar, Core, ctype, curl, date, dba, dom, enchant, exif, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, igbinary, imap, interbase, intl, json, ldap, libxml, mbstring, memcached, mongodb, mysqli, mysqlnd, oci8, openssl, pcntl, pcre, PDO, pdo_dblib, PDO_Firebird, pdo_mysql, PDO_OCI, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, pspell, rdkafka, readline, recode, redis, Reflection, session, shmop, SimpleXML, snmp, soap, sockets, sodium, SPL, sqlite3, standard, swoole, sysvmsg, sysvsem, sysvshm, tidy, tokenizer, uploadprogress, wddx, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib</td>
+   <td id="74-mods">bcmath, bz2, calendar, Core, ctype, curl, date, dba, dom, enchant, exif, FFI, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, igbinary, imap, interbase, intl, json, ldap, libxml, mbstring, memcached, mongodb, mysqli, mysqlnd, oci8, openssl, pcntl, pcre, PDO, pdo_dblib, PDO_Firebird, pdo_mysql, PDO_OCI, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, pspell, rdkafka, readline, recode, redis, Reflection, session, shmop, SimpleXML, snmp, soap, sockets, sodium, SPL, sqlite3, standard, swoole, sysvmsg, sysvsem, sysvshm, tidy, tokenizer, uploadprogress, wddx, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib</td>
   </tr>
  </tbody>
 </table>

--- a/build/ansible/group_vars/all.yml
+++ b/build/ansible/group_vars/all.yml
@@ -710,6 +710,7 @@ extensions_enabled:
   - dom
   - enchant
   - exif
+  - ffi
   - fileinfo
   - filter
   - ftp
@@ -896,6 +897,20 @@ extensions_available:
   exif:
     all:
       type: builtin
+  ffi:
+    disabled: [5.2, 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3]
+    all:
+      type: git
+      git_url: https://github.com/dstogov/php-ffi
+      command: |
+        curl -sS -O https://github.com/fpoirotte/php-ffi/commit/734630fe3d2e3efd343d3f3636b58446abd9c941.diff \
+        && git apply 734630fe3d2e3efd343d3f3636b58446abd9c941.diff \
+        && phpize \
+        && ./configure --with-ffi \
+        && make -j$(getconf _NPROCESSORS_ONLN) \
+        && make install \
+      build_dep: [libffi-dev]
+      run_dep: [libffi6]
   fileinfo:
     already_avail: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
     5.2:


### PR DESCRIPTION
# Add FFI (Foreign Function Interface) to PHP 7.4

This PR add the [Foreign Function Interface](https://github.com/dstogov/php-ffi) module to PHP 7.4.

### Docker

Once built and merged it will be available by (ETA from now: 8 hours):

* docker pull devilbox/php-fpm:7.4-mods-0.69 
* docker pull devilbox/php-fpm:7.4-prod-0.69 
* docker pull devilbox/php-fpm:7.4-work-0.69 

### Description

> FFI PHP extension provides a simple way to call native functions, access native variables and create/access data structures defined in C language. The API of the extension is very simple and demonstrated by the following example and its output.

> ```php
> <?php
> $libc = FFI::cdef("
>     int printf(const char *format, ...);
>     const char * getenv(const char *);
>     unsigned int time(unsigned int *);
> 
>     typedef unsigned int time_t;
>     typedef unsigned int suseconds_t;
> 
>     struct timeval {
>         time_t      tv_sec;
>         suseconds_t tv_usec;
>     };
> 
>     struct timezone {
>         int tz_minuteswest;
>         int tz_dsttime;
>     };
> 
> 	int gettimeofday(struct timeval *tv, struct timezone *tz);
> ", "libc.so.6");
> 
> $libc->printf("Hello World from %s!\n", "PHP");
> var_dump($libc->getenv("PATH"));
> var_dump($libc->time(null));
> 
> $tv = $libc->new("struct timeval");
> $tz = $libc->new("struct timezone");
> $libc->gettimeofday(FFI::addr($tv), FFI::addr($tz));
> var_dump($tv->tv_sec, $tv->tv_usec, $tz);
> ?>
> ```

https://github.com/dstogov/php-ffi