### PR TITLE
WIP: Re-enable imap for PHP 7.4

### DIFF
--- a/Dockerfiles/mods/Dockerfile-7.4
+++ b/Dockerfiles/mods/Dockerfile-7.4
@@ -24,6 +24,8 @@ ENV BUILD_DEPS \
 	freetds-dev \
 	libaio-dev \
 	libbz2-dev \
+	libc-client-dev \
+	libcurl4-openssl-dev \
 	libenchant-dev \
 	libevent-dev \
 	libfbclient2 \
@@ -34,6 +36,7 @@ ENV BUILD_DEPS \
 	libib-util \
 	libicu-dev \
 	libjpeg-dev \
+	libkrb5-dev \
 	libldap2-dev \
 	libmemcached-dev \
 	libnghttp2-dev \
@@ -60,6 +63,7 @@ ENV BUILD_DEPS \
 ENV RUN_DEPS \
 	libaio1 \
 	libaspell15 \
+	libc-client2007e \
 	libenchant1c2a \
 	libfbclient2 \
 	libffi6 \
@@ -161,6 +165,13 @@ RUN set -x \
 	&& docker-php-ext-enable igbinary \
 	&& (rm -rf /usr/local/lib/php/test/igbinary || true) \
 	&& (rm -rf /usr/local/lib/php/doc/igbinary || true) \
+	\
+# ---- Installing PHP Extension: imap ----
+	&& ln -s /usr/lib/x86_64-linux-gnu/libkrb5* /usr/lib/ \
+	&& /usr/local/bin/docker-php-ext-configure imap --with-kerberos --with-imap-ssl --with-imap \
+	&& /usr/local/bin/docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) imap \
+	&& (rm -rf /usr/local/lib/php/test/imap || true) \
+	&& (rm -rf /usr/local/lib/php/doc/imap || true) \
 	\
 # ---- Installing PHP Extension: interbase ----
 	&& /usr/local/bin/docker-php-ext-install -j$(getconf _NPROCESSORS_ONLN) interbase \
@@ -469,6 +480,8 @@ RUN set -x \
 	&& php-fpm -m | grep -oiE '^iconv$' \
 	&& php -m | grep -oiE '^igbinary$' \
 	&& php-fpm -m | grep -oiE '^igbinary$' \
+	&& php -m | grep -oiE '^imap$' \
+	&& php-fpm -m | grep -oiE '^imap$' \
 	&& php -m | grep -oiE '^interbase$' \
 	&& php-fpm -m | grep -oiE '^interbase$' \
 	&& php -m | grep -oiE '^intl$' \

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Check out this table to see which Docker image provides what PHP modules.
   <tr>
    <th>7.4</th>
    <td id="74-base">Core, ctype, curl, date, dom, fileinfo, filter, ftp, hash, iconv, json, libxml, mbstring, mysqlnd, openssl, pcre, PDO, pdo_sqlite, Phar, posix, readline, Reflection, session, SimpleXML, sodium, SPL, sqlite3, standard, tokenizer, xml, xmlreader, xmlwriter, zlib</td>
-   <td id="74-mods">bcmath, bz2, calendar, Core, ctype, curl, date, dba, dom, enchant, exif, FFI, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, igbinary, interbase, intl, json, ldap, libxml, mbstring, memcached, mongodb, mysqli, mysqlnd, oci8, openssl, pcntl, pcre, PDO, pdo_dblib, PDO_Firebird, pdo_mysql, PDO_OCI, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, pspell, rdkafka, readline, recode, redis, Reflection, session, shmop, SimpleXML, snmp, soap, sockets, sodium, SPL, sqlite3, standard, swoole, sysvmsg, sysvsem, sysvshm, tidy, tokenizer, uploadprogress, wddx, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib</td>
+   <td id="74-mods">bcmath, bz2, calendar, Core, ctype, curl, date, dba, dom, enchant, exif, FFI, fileinfo, filter, ftp, gd, gettext, gmp, hash, iconv, igbinary, imap, interbase, intl, json, ldap, libxml, mbstring, memcached, mongodb, mysqli, mysqlnd, oci8, openssl, pcntl, pcre, PDO, pdo_dblib, PDO_Firebird, pdo_mysql, PDO_OCI, pdo_pgsql, pdo_sqlite, pgsql, Phar, posix, pspell, rdkafka, readline, recode, redis, Reflection, session, shmop, SimpleXML, snmp, soap, sockets, sodium, SPL, sqlite3, standard, swoole, sysvmsg, sysvsem, sysvshm, tidy, tokenizer, uploadprogress, wddx, xml, xmlreader, xmlrpc, xmlwriter, xsl, Zend OPcache, zip, zlib</td>
   </tr>
  </tbody>
 </table>

--- a/build/ansible/group_vars/all.yml
+++ b/build/ansible/group_vars/all.yml
@@ -1026,8 +1026,6 @@ extensions_available:
       build_dep: [libmagickwand-dev]
       run_dep: [libmagickwand-6.q16-3]
   imap:
-    disabled: [7.4]   # TODO: re-enable. currently fails with: configure: error: OpenSSL libraries not found.
-
     all:
       type: builtin
       pre: ln -s /usr/lib/x86_64-linux-gnu/libkrb5* /usr/lib/


### PR DESCRIPTION
# Re-enable imap for PHP 7.4

Currently fails with: configure: error: OpenSSL libraries not found.

* Refs: https://github.com/devilbox/docker-php-fpm/pull/93