### PR TITLE
Fixed typo in MySQL backup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,7 +1228,7 @@ $ docker run -d \
     -e MYSQL_BACKUP_USER=root \
     -e MYSQL_BACKUP_PASS=somepass \
     -e MYSQL_BACKUP_HOST=mysql \
-    -v ~/backups:/shared/backsup \
+    -v ~/backups:/shared/backups \
     --name php \
     -t devilbox/php-fpm:7.2-work
 


### PR DESCRIPTION
The container-side path of the volume had a typo in the README.md example.