### PR TITLE
Release v0.100

### DIFF
--- a/Dockerfiles/base/data/docker-entrypoint.d/101-uid-gid.sh
+++ b/Dockerfiles/base/data/docker-entrypoint.d/101-uid-gid.sh
@@ -61,7 +61,7 @@ set_uid() {
 			# Change uid and fix homedir permissions
 			log "info" "Changing user '${username}' uid to: ${uid}" "${debug}"
 			run "usermod -u ${uid} ${username}" "${debug}"
-			run "chown -R ${username} ${homedir}" "${debug}"
+			run "chown -R ${username} ${homedir} || true" "${debug}"
 			run "chown -R ${username} /var/lib/php/session" "${debug}"
 			run "chown -R ${username} /var/lib/php/wsdlcache" "${debug}"
 		fi
@@ -103,7 +103,7 @@ set_gid() {
 			# Change ugd and fix homedir permissions
 			log "info" "Changing group '${groupname}' gid to: ${gid}" "${debug}"
 			run "groupmod -g ${gid} ${groupname}" "${debug}"
-			run "chown -R :${groupname} ${homedir}" "${debug}"
+			run "chown -R :${groupname} ${homedir} || true" "${debug}"
 			run "chown -R :${groupname} /var/lib/php/session" "${debug}"
 			run "chown -R :${groupname} /var/lib/php/wsdlcache" "${debug}"
 		fi

--- a/Dockerfiles/work/Dockerfile-5.2
+++ b/Dockerfiles/work/Dockerfile-5.2
@@ -191,7 +191,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \

--- a/Dockerfiles/work/Dockerfile-5.3
+++ b/Dockerfiles/work/Dockerfile-5.3
@@ -208,7 +208,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -264,7 +264,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-5.4
+++ b/Dockerfiles/work/Dockerfile-5.4
@@ -237,7 +237,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -293,7 +293,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-5.5
+++ b/Dockerfiles/work/Dockerfile-5.5
@@ -241,7 +241,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -298,7 +298,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-5.6
+++ b/Dockerfiles/work/Dockerfile-5.6
@@ -254,7 +254,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -311,7 +311,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-7.0
+++ b/Dockerfiles/work/Dockerfile-7.0
@@ -254,7 +254,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -311,7 +311,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-7.1
+++ b/Dockerfiles/work/Dockerfile-7.1
@@ -254,7 +254,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -311,7 +311,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-7.2
+++ b/Dockerfiles/work/Dockerfile-7.2
@@ -254,7 +254,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -312,7 +312,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-7.3
+++ b/Dockerfiles/work/Dockerfile-7.3
@@ -254,7 +254,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -298,7 +298,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-7.4
+++ b/Dockerfiles/work/Dockerfile-7.4
@@ -254,7 +254,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -293,7 +293,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/Dockerfiles/work/Dockerfile-8.0
+++ b/Dockerfiles/work/Dockerfile-8.0
@@ -197,7 +197,7 @@ RUN set -eux \
  \
 	\
 # -------------------- mhsendmail --------------------
-	&& wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+	&& curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
 && chmod +x mhsendmail_linux_amd64 \
 && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
  \
@@ -236,7 +236,7 @@ RUN set -eux \
  \
 	\
 # -------------------- phpmd --------------------
-	&& wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+	&& curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
 && chmod +x /usr/local/bin/phpmd \
  \

--- a/build/ansible/group_vars/all/work.yml
+++ b/build/ansible/group_vars/all/work.yml
@@ -572,7 +572,7 @@ software_available:
   mhsendmail:
     all:
       command: |
-        wget --no-hsts https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 \
+        curl -sS -L https://github.com/devilbox/mhsendmail/releases/download/v0.3.0/mhsendmail_linux_amd64 > mhsendmail_linux_amd64 \
         && chmod +x mhsendmail_linux_amd64 \
         && mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail \
   mysqldumpsecure:
@@ -737,7 +737,7 @@ software_available:
     check: phpmd --version | grep -E '^PHPMD [.0-9]+'
     all:
       command: |
-        wget --no-hsts https://phpmd.org/static/latest/phpmd.phar \
+        curl -sS -L https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
         && mv phpmd.phar /usr/local/bin/phpmd \
         && chmod +x /usr/local/bin/phpmd \
   phpunit:


### PR DESCRIPTION
# Release v0.100

Allow chown homedir to fail (e.g.: for read-only sub-mount)