### PR TITLE
Add sorting for startup files

### DIFF
--- a/Dockerfiles/prod/data/docker-entrypoint.d/310-custom-startup-scripts.sh
+++ b/Dockerfiles/prod/data/docker-entrypoint.d/310-custom-startup-scripts.sh
@@ -19,7 +19,7 @@ execute_custom_scripts() {
 	if [ ! -d "${script_dir}" ]; then
 		run "mkdir -p ${script_dir}" "${debug}"
 	fi
-	script_files="$( find -L "${script_dir}" -type f -iname '*.sh' )"
+	script_files="$( find -L "${script_dir}" -type f -iname '*.sh' | sort -n )"
 
 	# loop over them line by line
 	IFS='


### PR DESCRIPTION
Alphanumerically sort files found in `/startup.1.d` and `/startup.2.d` directories, to prevent non regular script execution.

Not sorting whatever `find` finds, ends up in a messy script execution order like so:
```
# find -L /startup.1.d -type f -iname '*.sh'
/startup.1.d/050-fix-permissions.sh
/startup.1.d/100-start-scheduler.sh
/startup.1.d/010-copy-app-files.sh
/startup.1.d/011-link-history-docs.sh
/startup.1.d/020-copy-config-files.sh
/startup.1.d/030-add-opcache-dashboard.sh
/startup.1.d/031-add-phpinfo.sh
```

Piping `find`'s output to `sort -n` actually fixes the order resulting in what we're actually expecting the execution order to be:
```
# find -L /startup.1.d -type f -iname '*.sh' | sort -n
/startup.1.d/010-copy-app-files.sh
/startup.1.d/011-link-history-docs.sh
/startup.1.d/020-copy-config-files.sh
/startup.1.d/030-add-opcache-dashboard.sh
/startup.1.d/031-add-phpinfo.sh
/startup.1.d/050-fix-permissions.sh
/startup.1.d/100-start-scheduler.sh
```