### PR TITLE
Release 0.116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ## Unreleased
 
 
+## Release 0.116
+
+#### Fixed
+- [#749](https://github.com/cytopia/devilbox/issues/749) Fix to disable PHP modules without trailing `*.so` extension
+
+
 ## Release 0.115
 
 #### Fixed

--- a/Dockerfiles/prod/data/docker-entrypoint.d/309-disable-modules.sh
+++ b/Dockerfiles/prod/data/docker-entrypoint.d/309-disable-modules.sh
@@ -33,7 +33,7 @@ disable_modules() {
 			mod="$( echo "${mod}" | xargs )" # trim
 
 			# Find all config files that enable that module
-			files="$( grep -Er "^(zend_)?extension.*(=|/)${mod}\.so" "${cfg_path}" || true )"
+			files="$( grep -Er "^(zend_)?extension.*(=|/)${mod}(\\.so)?\$" "${cfg_path}" || true )"
 
 			if [ -n "${files}" ]; then
 				while read -r f; do


### PR DESCRIPTION
## Release 0.116

#### Fixed
- [#749](https://github.com/cytopia/devilbox/issues/749) Fix to disable PHP modules without trailing `*.so` extension
