### PR TITLE
Release 0.120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ## Unreleased
 
 
+## Release 0.120
+
+#### Fixed
+- Fixed `zsh` install for PHP 5.6 and 7.0
+
+
 ## Release 0.119
 
 #### Fixed

--- a/Dockerfiles/work/Dockerfile-5.6
+++ b/Dockerfiles/work/Dockerfile-5.6
@@ -120,7 +120,7 @@ RUN set -eux \
 		zip \
 		zlib1g-dev \
 		zsh \
-		zsh-common=5.3.1-4 \
+		zsh-common \
 	&& DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false apt-utils \
 	&& rm -rf /var/lib/apt/lists/* \
 	\

--- a/Dockerfiles/work/Dockerfile-7.0
+++ b/Dockerfiles/work/Dockerfile-7.0
@@ -120,7 +120,7 @@ RUN set -eux \
 		zip \
 		zlib1g-dev \
 		zsh \
-		zsh-common=5.3.1-4 \
+		zsh-common \
 	&& DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false apt-utils \
 	&& rm -rf /var/lib/apt/lists/* \
 	\

--- a/build/ansible/DOCKERFILES/Dockerfile-work.j2
+++ b/build/ansible/DOCKERFILES/Dockerfile-work.j2
@@ -141,7 +141,7 @@ RUN set -eux \
 		zlib1g-dev \
 		zsh \
 {% if php_version in [5.6, 7.0] %}
-		zsh-common=5.3.1-4 \
+		zsh-common \
 {% endif %}
 	&& DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false apt-utils \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Release 0.120

#### Fixed
- Fixed `zsh` install for PHP 5.6 and 7.0
