### PR TITLE
Update url for pip 2.7

### DIFF
--- a/Dockerfiles/work/Dockerfile-5.2
+++ b/Dockerfiles/work/Dockerfile-5.2
@@ -139,7 +139,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-5.3
+++ b/Dockerfiles/work/Dockerfile-5.3
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-5.4
+++ b/Dockerfiles/work/Dockerfile-5.4
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-5.5
+++ b/Dockerfiles/work/Dockerfile-5.5
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-5.6
+++ b/Dockerfiles/work/Dockerfile-5.6
@@ -148,7 +148,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-7.0
+++ b/Dockerfiles/work/Dockerfile-7.0
@@ -148,7 +148,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-7.1
+++ b/Dockerfiles/work/Dockerfile-7.1
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-7.2
+++ b/Dockerfiles/work/Dockerfile-7.2
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-7.3
+++ b/Dockerfiles/work/Dockerfile-7.3
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-7.4
+++ b/Dockerfiles/work/Dockerfile-7.4
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-8.0
+++ b/Dockerfiles/work/Dockerfile-8.0
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/Dockerfiles/work/Dockerfile-8.1
+++ b/Dockerfiles/work/Dockerfile-8.1
@@ -147,7 +147,7 @@ RUN set -eux \
 && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/* \
 \
-&& curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+&& curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
  \
 	\
 # -------------------- nvm --------------------

--- a/build/ansible/group_vars/all/work.yml
+++ b/build/ansible/group_vars/all/work.yml
@@ -413,7 +413,7 @@ software_available:
         && DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
         && rm -rf /var/lib/apt/lists/* \
         \
-        && curl -sS -L --fail https://bootstrap.pypa.io/get-pip.py | python \
+        && curl -sS -L --fail https://bootstrap.pypa.io/2.7/get-pip.py | python \
   # nvm is a dependency for others
   nvm:
     check: su  -c '. /opt/nvm/nvm.sh; nvm --version' devilbox | grep -E '^[0-9][.0-9]+'


### PR DESCRIPTION
get-pip.py for Python 2.7 changed URL.   If not changed the image fails to build.