### PR TITLE
feat: add php-cs-fixer v3 to PHP 7.2 to 8.1 images

### DIFF
--- a/Dockerfiles/work/Dockerfile-7.2
+++ b/Dockerfiles/work/Dockerfile-7.2
@@ -333,7 +333,7 @@ RUN set -eux \
  \
 	\
 # -------------------- php-cs-fixer --------------------
-	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v2.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
+	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v3.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
 && chmod +x /usr/local/bin/php-cs-fixer \
  \
 	\

--- a/Dockerfiles/work/Dockerfile-7.3
+++ b/Dockerfiles/work/Dockerfile-7.3
@@ -333,7 +333,7 @@ RUN set -eux \
  \
 	\
 # -------------------- php-cs-fixer --------------------
-	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v2.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
+	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v3.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
 && chmod +x /usr/local/bin/php-cs-fixer \
  \
 	\

--- a/Dockerfiles/work/Dockerfile-7.4
+++ b/Dockerfiles/work/Dockerfile-7.4
@@ -332,6 +332,11 @@ RUN set -eux \
 && chmod +x /usr/local/bin/phpcbf \
  \
 	\
+# -------------------- php-cs-fixer --------------------
+	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v3.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
+&& chmod +x /usr/local/bin/php-cs-fixer \
+ \
+	\
 # -------------------- phpmd --------------------
 	&& curl -sS -L --fail https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
@@ -600,6 +605,7 @@ RUN set -eux \
 	&& phalcon commands | grep -E '[0-9][.0-9]+' \
 	&& phpcs --version | grep -E 'version [0-9][.0-9]+' \
 	&& phpcbf --version | grep -E 'version [0-9][.0-9]+' \
+	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
 	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \

--- a/Dockerfiles/work/Dockerfile-8.0
+++ b/Dockerfiles/work/Dockerfile-8.0
@@ -260,6 +260,11 @@ RUN set -eux \
 && chmod +x /usr/local/bin/phpcbf \
  \
 	\
+# -------------------- php-cs-fixer --------------------
+	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v3.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
+&& chmod +x /usr/local/bin/php-cs-fixer \
+ \
+	\
 # -------------------- phpmd --------------------
 	&& curl -sS -L --fail https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
@@ -498,6 +503,7 @@ RUN set -eux \
 	&& mysqldump-secure --version | grep -E 'Version:\s*[0-9][.0-9]+' \
 	&& phpcs --version | grep -E 'version [0-9][.0-9]+' \
 	&& phpcbf --version | grep -E 'version [0-9][.0-9]+' \
+	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
 	&& wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)" \

--- a/Dockerfiles/work/Dockerfile-8.1
+++ b/Dockerfiles/work/Dockerfile-8.1
@@ -260,6 +260,11 @@ RUN set -eux \
 && chmod +x /usr/local/bin/phpcbf \
  \
 	\
+# -------------------- php-cs-fixer --------------------
+	&& curl -sS -L --fail https://cs.symfony.com/download/php-cs-fixer-v3.phar > /usr/local/bin/php-cs-fixer 2>/dev/null \
+&& chmod +x /usr/local/bin/php-cs-fixer \
+ \
+	\
 # -------------------- phpmd --------------------
 	&& curl -sS -L --fail https://phpmd.org/static/latest/phpmd.phar > phpmd.phar \
 && mv phpmd.phar /usr/local/bin/phpmd \
@@ -498,6 +503,7 @@ RUN set -eux \
 	&& mysqldump-secure --version | grep -E 'Version:\s*[0-9][.0-9]+' \
 	&& phpcs --version | grep -E 'version [0-9][.0-9]+' \
 	&& phpcbf --version | grep -E 'version [0-9][.0-9]+' \
+	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
 	&& wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)" \


### PR DESCRIPTION
Hello,
PHP-CS-Fixer V3 should be usable in all the PHP images starting from 7.2.
Thanks!