### PR TITLE
Release 0.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ## Unreleased
 
 
+## Release 0.140
+
+### Changed
+- Ensure apt Jessie repositories are trusted beyond EOL
+
+
 ## Release 0.139
 
 #### Added

--- a/Dockerfiles/work/Dockerfile-5.2
+++ b/Dockerfiles/work/Dockerfile-5.2
@@ -55,7 +55,7 @@ RUN set -eux \
 		gnupg \
 		\
 	&& echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until \
-	&& echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+	&& echo "deb [trusted=yes] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
 	&& curl -sS -L --fail "https://packages.blackfire.io/gpg.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
 	&& echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list \
 	\

--- a/Dockerfiles/work/Dockerfile-5.3
+++ b/Dockerfiles/work/Dockerfile-5.3
@@ -55,7 +55,7 @@ RUN set -eux \
 		gnupg \
 		\
 	&& echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until \
-	&& echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+	&& echo "deb [trusted=yes] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
 	&& curl -sS -L --fail "https://packages.blackfire.io/gpg.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
 	&& echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list \
 	\

--- a/Dockerfiles/work/Dockerfile-5.4
+++ b/Dockerfiles/work/Dockerfile-5.4
@@ -55,7 +55,7 @@ RUN set -eux \
 		gnupg \
 		\
 	&& echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until \
-	&& echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+	&& echo "deb [trusted=yes] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
 	&& curl -sS -L --fail "https://packages.blackfire.io/gpg.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
 	&& echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list \
 	\

--- a/Dockerfiles/work/Dockerfile-5.5
+++ b/Dockerfiles/work/Dockerfile-5.5
@@ -55,7 +55,7 @@ RUN set -eux \
 		gnupg \
 		\
 	&& echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until \
-	&& echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+	&& echo "deb [trusted=yes] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
 	&& curl -sS -L --fail "https://packages.blackfire.io/gpg.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
 	&& echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list \
 	\

--- a/build/ansible/group_vars/all/work.yml
+++ b/build/ansible/group_vars/all/work.yml
@@ -204,19 +204,19 @@ apt_repositories_available:
     # [Jessie]
     5.2:
       pre: echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until
-      deb: deb http://archive.debian.org/debian {{ os_release[5.2].debian }}-backports main
+      deb: deb [trusted=yes] http://archive.debian.org/debian {{ os_release[5.2].debian }}-backports main
     # [Jessie]
     5.3:
       pre: echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until
-      deb: deb http://archive.debian.org/debian {{ os_release[5.3].debian }}-backports main
+      deb: deb [trusted=yes] http://archive.debian.org/debian {{ os_release[5.3].debian }}-backports main
     # [Jessie]
     5.4:
       pre: echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until
-      deb: deb http://archive.debian.org/debian {{ os_release[5.4].debian }}-backports main
+      deb: deb [trusted=yes] http://archive.debian.org/debian {{ os_release[5.4].debian }}-backports main
     # [Jessie]
     5.5:
       pre: echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until
-      deb: deb http://archive.debian.org/debian {{ os_release[5.5].debian }}-backports main
+      deb: deb [trusted=yes] http://archive.debian.org/debian {{ os_release[5.5].debian }}-backports main
     # [Stretch]
     5.6:
       pre: apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138


### PR DESCRIPTION
## Release 0.140

### Changed
- Ensure apt Jessie repositories are trusted beyond EOL

