### PR TITLE
wkhtmltopdf new way of install (from wkhtmltopdf/packaging)

### DIFF
--- a/Dockerfiles/work/Dockerfile-5.2
+++ b/Dockerfiles/work/Dockerfile-5.2
@@ -264,12 +264,12 @@ fi \
  \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-5.3
+++ b/Dockerfiles/work/Dockerfile-5.3
@@ -318,12 +318,12 @@ fi \
  \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-5.4
+++ b/Dockerfiles/work/Dockerfile-5.4
@@ -352,12 +352,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-5.5
+++ b/Dockerfiles/work/Dockerfile-5.5
@@ -358,12 +358,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-5.6
+++ b/Dockerfiles/work/Dockerfile-5.6
@@ -378,12 +378,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-7.0
+++ b/Dockerfiles/work/Dockerfile-7.0
@@ -359,12 +359,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-7.1
+++ b/Dockerfiles/work/Dockerfile-7.1
@@ -352,12 +352,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-7.2
+++ b/Dockerfiles/work/Dockerfile-7.2
@@ -372,12 +372,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-7.3
+++ b/Dockerfiles/work/Dockerfile-7.3
@@ -373,12 +373,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-7.4
+++ b/Dockerfiles/work/Dockerfile-7.4
@@ -373,12 +373,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-8.0
+++ b/Dockerfiles/work/Dockerfile-8.0
@@ -307,12 +307,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-8.1
+++ b/Dockerfiles/work/Dockerfile-8.1
@@ -307,12 +307,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/Dockerfiles/work/Dockerfile-8.2
+++ b/Dockerfiles/work/Dockerfile-8.2
@@ -291,12 +291,12 @@ fi \
 	&& chmod +x /usr/local/bin/symfony \
 	\
 # -------------------- wkhtmltopdf --------------------
-	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
+	&& VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )" \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
   DEBIAN_FRONTEND=noninteractive apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
     libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+  && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
   && dpkg -i /tmp/wkhtmltopdf.deb \
   && rm -f /tmp/wkhtmltopdf.deb; \
 fi \

--- a/build/ansible/group_vars/all/work.yml
+++ b/build/ansible/group_vars/all/work.yml
@@ -1308,46 +1308,46 @@ software_available:
   wkhtmltopdf:
     check: if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi
     5.2:
-      pre: VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )"
+      pre: VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )"
       command: |
         if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \
     5.3:
-      pre: VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )"
+      pre: VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )"
       command: |
         if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \
     5.4:
-      pre: VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )"
+      pre: VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )"
       command: |
         if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \
     5.5:
-      pre: VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )"
+      pre: VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/wkhtmltopdf/releases | awk -F\" '/wkhtmltopdf.*.jessie_amd64\.deb/{print $(NF-1)}' | head -1 )"
       command: |
         if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \
@@ -1357,7 +1357,7 @@ software_available:
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \
@@ -1367,18 +1367,18 @@ software_available:
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \
     all:
-      pre: VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )"
+      pre: VERSION="$(curl -sSL -L --fail https://api.github.com/repos/wkhtmltopdf/packaging/releases | awk -F\" '/wkhtmltopdf.*.stretch_amd64\.deb/{print $(NF-1)}' | head -1 )"
       command: |
         if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then \
           DEBIAN_FRONTEND=noninteractive apt-get update -qq \
           && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
             libfontenc1 libxfont2 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  https://github.com/${VERSION} \
+          && curl -sS -L --fail -o /tmp/wkhtmltopdf.deb  ${VERSION} \
           && dpkg -i /tmp/wkhtmltopdf.deb \
           && rm -f /tmp/wkhtmltopdf.deb; \
         fi \


### PR DESCRIPTION
wkhtmltopdf was move to https://github.com/wkhtmltopdf/packaging 

See https://github.com/wkhtmltopdf/packaging