### PR TITLE
symfony cli new way of install (from symfony-cli/symfony-cli)

### DIFF
--- a/Dockerfiles/work/Dockerfile-5.4
+++ b/Dockerfiles/work/Dockerfile-5.4
@@ -347,9 +347,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )" \
@@ -755,7 +757,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-5.5
+++ b/Dockerfiles/work/Dockerfile-5.5
@@ -353,9 +353,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+jessie_amd64\.deb' | head -1 )" \
@@ -770,7 +772,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-5.6
+++ b/Dockerfiles/work/Dockerfile-5.6
@@ -373,9 +373,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -788,7 +790,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-7.0
+++ b/Dockerfiles/work/Dockerfile-7.0
@@ -354,9 +354,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -767,7 +769,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-7.1
+++ b/Dockerfiles/work/Dockerfile-7.1
@@ -347,9 +347,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -760,7 +762,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-7.2
+++ b/Dockerfiles/work/Dockerfile-7.2
@@ -367,9 +367,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -782,7 +784,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-7.3
+++ b/Dockerfiles/work/Dockerfile-7.3
@@ -368,9 +368,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -783,7 +785,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-7.4
+++ b/Dockerfiles/work/Dockerfile-7.4
@@ -368,9 +368,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -783,7 +785,7 @@ fi \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
 	&& phpunit --version | grep -iE '^PHPUnit\s[0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-8.0
+++ b/Dockerfiles/work/Dockerfile-8.0
@@ -302,9 +302,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -696,7 +698,7 @@ fi \
 	&& phpcbf --version | grep -E 'version [0-9][.0-9]+' \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-8.1
+++ b/Dockerfiles/work/Dockerfile-8.1
@@ -302,9 +302,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -696,7 +698,7 @@ fi \
 	&& phpcbf --version | grep -E 'version [0-9][.0-9]+' \
 	&& php-cs-fixer --version 2>&1 | grep -E 'Fixer\s+(version\s*)?[-_.0-9]+\s+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/Dockerfiles/work/Dockerfile-8.2
+++ b/Dockerfiles/work/Dockerfile-8.2
@@ -286,9 +286,11 @@ fi \
  \
 	\
 # -------------------- symfony --------------------
-	&& SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )" \
-	&& curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony \
-	&& chmod +x /usr/local/bin/symfony \
+	&& VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')" \
+	&& curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+&& dpkg -i /tmp/symfonycli.deb \
+&& rm -f /tmp/symfonycli.deb \
+ \
 	\
 # -------------------- wkhtmltopdf --------------------
 	&& VERSION="$( curl -sSL -L --fail https://github.com/wkhtmltopdf/wkhtmltopdf/releases | grep -Eo '/wkhtmltopdf/.+stretch_amd64\.deb' | head -1 )" \
@@ -678,7 +680,7 @@ fi \
 	&& phpcs --version | grep -E 'version [0-9][.0-9]+' \
 	&& phpcbf --version | grep -E 'version [0-9][.0-9]+' \
 	&& phpmd --version | grep -E '^PHPMD [0-9][.0-9]+' \
-	&& symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+' \
+	&& symfony -V | grep -Ei 'version\s[0-9][.0-9]+' \
 	&& if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi \
 	&& wp --allow-root --version | grep -E '[0-9][.0-9]+' \
 	\

--- a/build/ansible/group_vars/all/work.yml
+++ b/build/ansible/group_vars/all/work.yml
@@ -1300,11 +1300,13 @@ software_available:
         && chmod +x /usr/local/bin/phpunit \
   symfony:
     disabled: [5.2, 5.3]
-    check: symfony -V | grep -Ei 'version\s*.*v[0-9][.0-9]+'
+    check: symfony -V | grep -Ei 'version\s[0-9][.0-9]+'
     all:
-      pre: SYMFONY_VERSION="$( curl -sS -L --fail https://get.symfony.com/cli/LATEST )"
-      command: curl -sS -L --fail "https://github.com/symfony/cli/releases/download/v${SYMFONY_VERSION}/symfony_linux_$(dpkg-architecture --query DEB_HOST_ARCH)" > /usr/local/bin/symfony
-      post: chmod +x /usr/local/bin/symfony
+      pre: VERSION="$(curl -s https://api.github.com/repos/symfony-cli/symfony-cli/releases/latest | awk -F\" '/symfony-cli_.*._amd64\.deb/{print $(NF-1)}' | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')"
+      command: |
+        curl -sS -L --fail -o /tmp/symfonycli.deb  https://github.com/symfony-cli/symfony-cli/releases/download/v${VERSION}/symfony-cli_${VERSION}_$(dpkg-architecture --query DEB_HOST_ARCH).deb \
+        && dpkg -i /tmp/symfonycli.deb \
+        && rm -f /tmp/symfonycli.deb \
   wkhtmltopdf:
     check: if [ "$(dpkg-architecture --query DEB_HOST_ARCH)" = "amd64" ]; then wkhtmltopdf --version | grep -E "^wkhtmltopdf [0-9][.0-9]+\s+\(.+patched.+\)"; fi
     5.2:


### PR DESCRIPTION
Old way get symfony cli is deprecated

Sea https://github.com/symfony-cli/symfony-cli