### PR TITLE
Update options.yml

### DIFF
--- a/php_modules/ioncube/options.yml
+++ b/php_modules/ioncube/options.yml
@@ -7,7 +7,7 @@ name: ioncube
 # ioncube on amd64 is only available from 4.1 up to 7.4
 # ioncube on arm64 is only available from 5.5 up to 7.4
 # TODO: Remove some exludes, as ioncube had some recent updates
-exclude: [5.2, 5.3, 5.4, 8.0, 8.1, 8.2]
+exclude: [5.2, 5.3, 5.4, 8.2]
 
 # In order for this module to built correctly against all dependencies,
 # the following modules must have been built first.


### PR DESCRIPTION
Removed 8.0 and 8.1 from  exclude as its is supported by Ioncube 12